### PR TITLE
v1.0.2 Fix status Uppercase & SERVER_TESTING env

### DIFF
--- a/bin/jira.py
+++ b/bin/jira.py
@@ -320,7 +320,8 @@ class Jira():
 
     def get_issue_detail(
             self,
-            project: str):
+            project: str,
+            server: bool):
 
         """
         Function to do an issue search and return its
@@ -331,6 +332,8 @@ class Jira():
         if self.debug:
             # debug helpdesk
             desk = 'EBHD'
+            if server:
+                desk = 'EBH'
         else:
             desk = 'EBH'
 

--- a/bin/util.py
+++ b/bin/util.py
@@ -88,7 +88,8 @@ def post_message_to_slack(
                         f'{duration.days % 7} days ago\n'
                         )
                     data_count += 1
-                elif duration.days > 30 and status != 'ALL SAMPLES RELEASED':
+                elif duration.days > 30 and \
+                        status.upper() != 'ALL SAMPLES RELEASED':
                     # if ticket is old
                     # and status still not released
                     final_msg.append(

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ def main():
     try:
         SLACK_TOKEN = os.environ['SLACK_TOKEN']
         DEBUG = os.environ.get('ANSIBLE_DEBUG', False)
+        SERVER_TESTING = os.environ.get('ANSIBLE_TESTING', False)
 
         GENETIC_DIR = os.environ['ANSIBLE_GENETICDIR']
         LOGS_DIR = os.environ['ANSIBLE_LOGSDIR']
@@ -310,7 +311,10 @@ def main():
         old_enough = check_age(created_date, today, ANSIBLE_WEEK)
 
         # get proj jira details
-        assay, status, key = jira.get_issue_detail(project)
+        if not SERVER_TESTING:
+            assay, status, key = jira.get_issue_detail(project, False)
+        else:
+            assay, status, key = jira.get_issue_detail(project, True)
 
         if project_data and uploaded:
             # found the 002 project & found in staging52


### PR DESCRIPTION
# Changes
- added `status.upper()` for more accurate status comparison e.g. 220916_A01303_0098_BHGNLYDRX2
- added `SERVER_TESTING` for testing in server. When True, `jira.search_issue` will target 'EBH' project instead of 'EBHD' which is more for development purpose.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/ansible-run-monitoring/15)
<!-- Reviewable:end -->
