### PR TITLE
sending notification to alert rather than log

### DIFF
--- a/main.py
+++ b/main.py
@@ -255,7 +255,7 @@ def main():
                 log.info(today)
                 if runs:
                     post_message_to_slack(
-                        channel="egg-logs",
+                        channel="egg-alerts",
                         token=SLACK_TOKEN,
                         data=ansible_pickle,
                         debug=DEBUG,
@@ -276,7 +276,7 @@ def main():
         # today is the 24th and not a weekend or --notification tag
         if runs:
             post_message_to_slack(
-                channel="egg-logs",
+                channel="egg-alerts",
                 token=SLACK_TOKEN,
                 data=ansible_pickle,
                 debug=DEBUG,


### PR DESCRIPTION
- send to-be-deleted notification to #egg-alerts, sending stale run notification stayed the same (#egg-logs)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/ansible-run-monitoring/25)
<!-- Reviewable:end -->
