### PR TITLE
v1.1.0 change deletion logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ env
 .pytest_cache
 *.log
 *.pickle
+*.pkl
+*.conf

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ env
 *.pickle
 *.pkl
 *.conf
+*.env
+*.txt

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -48,4 +48,5 @@ def get_logger(logger_name):
     logger.addHandler(get_file_handler())
 
     logger.propagate = False
+
     return logger

--- a/bin/helper.py
+++ b/bin/helper.py
@@ -6,6 +6,7 @@ directory defined below
 
 import logging
 from logging.handlers import TimedRotatingFileHandler
+import os
 from pathlib import Path
 import sys
 
@@ -13,10 +14,19 @@ import sys
 FORMATTER = logging.Formatter(
     "%(asctime)s:%(name)s:%(module)s:%(levelname)s:%(message)s"
 )
-LOG_FILE = "/log/monitoring/ansible-run-monitoring.log"
 
-Path("/log/monitoring").mkdir(parents=True, exist_ok=True)
-Path(LOG_FILE).touch(exist_ok=True)
+if os.access("/log", os.W_OK):
+    # running in Docker container
+    LOG_FILE = "/log/monitoring/ansible-run-monitoring.log"
+
+    Path("/log/monitoring").mkdir(parents=True, exist_ok=True)
+    Path(LOG_FILE).touch(exist_ok=True)
+else:
+    # running elsewhere (likely testing)
+    LOG_FILE = os.path.join(os.getcwd(), "ansible-run-monitoring.log")
+
+    Path(os.getcwd()).mkdir(parents=True, exist_ok=True)
+    Path(LOG_FILE).touch(exist_ok=True)
 
 
 def get_console_handler():

--- a/bin/jira.py
+++ b/bin/jira.py
@@ -138,6 +138,7 @@ class Jira:
         self.url = f"{api_url}/servicedeskapi/servicedesk"
         self.debug = debug
 
+
     def get_all_service_desk(self):
         """
         Get all service desk on Jira
@@ -145,6 +146,7 @@ class Jira:
         url = self.url
         response = self.http.get(url, headers=self.headers, auth=self.auth)
         return response.json()
+
 
     def get_queues_in_service_desk(self, servicedesk_id):
         """
@@ -154,9 +156,10 @@ class Jira:
         response = self.http.get(url, headers=self.headers, auth=self.auth)
         return response.json()
 
+
     def get_all_issues(
-        self, servicedesk_id: int, queue_id: int, trimmed: bool = False
-    ) -> list:
+            self, servicedesk_id: int, queue_id: int, trimmed: bool = False
+        ) -> list:
         """
         Get all issues of a queue in specified service desk
         Inputs:
@@ -190,6 +193,7 @@ class Jira:
             return result
         return issues
 
+
     def get_issue(self, issue_id: Union[int, str], trimmed: bool = False):
         """
         Get details of specified issue
@@ -202,6 +206,7 @@ class Jira:
         if trimmed:
             return Issue(response.json()).__dict__
         return response.json()
+
 
     def search_issue(self, sequence_name: str, project_name: str = "EBH") -> dict:
         """
@@ -224,7 +229,8 @@ class Jira:
 
         return response.json()
 
-    def get_assay(issue: dict):
+
+    def get_assay(self, issue: dict):
         """
         Get assay options of an issue
         """
@@ -232,7 +238,8 @@ class Jira:
             return issue["fields"]["customfield_10070"][0].get("value", None)
         return None
 
-    def get_issue_detail(self, project: str, server: bool) -> tuple:
+
+    def get_issue_detail(self, run: str, server: bool) -> tuple:
         """
         Function to do an issue search and return its
         detail
@@ -250,7 +257,7 @@ class Jira:
             # debug = False / server = True
             desk = "EBH"
 
-        jira_data = self.search_issue(project, project_name=desk)
+        jira_data = self.search_issue(run, project_name=desk)
 
         # if Jira return no result / error
         if (jira_data["total"] < 1) or ("errorMessages" in jira_data):
@@ -260,28 +267,32 @@ class Jira:
 
         elif jira_data["total"] > 1:
             # more than one issue found
-            filtered_issues: list[Issue] = []
+            filtered_issues = []
 
             for result in jira_data["issues"]:
                 # remove those that start with 'RE' (replies)
-                # exclude those that're not Sequencing requestType (39)
-                if ("customfield_10010" in result["fields"]) and (
-                    not result["fields"]["summary"].startswith("RE")
-                ):
-                    if (result["fields"]["customfield_10010"] is not None) and (
-                        result["fields"]["customfield_10010"]["requestType"]["id"]
-                        == "39"
-                    ):
-                        filtered_issues.append(Issue(result))
+                # exclude those that're not sequencing issuetype
+                sequencing_run = result['fields'].get(
+                    "issuetype", {}).get("id", "") == "10179"
+                reply = result['fields']['summary'].startswith("RE")
+
+                if sequencing_run and not reply:
+                    filtered_issues.append(Issue(result))
 
             if len(filtered_issues) == 1:
                 assay = filtered_issues[0].assay
                 status = filtered_issues[0].status.name
                 key = filtered_issues[0].key
+
+            elif len(filtered_issues) == 0:
+                assay = "No Jira ticket found after filtering"
+                status = "No Jira ticket found after filtering"
+                key = None
+
             else:
                 assay = "More than 1 Jira ticket detected"
                 status = "More than 1 Jira ticket detected"
-                key = None
+                key = "Multiple"
         else:
             # only one Jira ticket found
             issue = Issue(jira_data["issues"][0])
@@ -291,16 +302,17 @@ class Jira:
 
         return assay, status, key
 
+
     def create_issue(
-        self,
-        summary: str,
-        issue_id: int,
-        project_id: int,
-        reporter_id: str,
-        priority_id: int,
-        desc: str,
-        assay: bool,
-    ) -> dict:
+            self,
+            summary: str,
+            issue_id: int,
+            project_id: int,
+            reporter_id: str,
+            priority_id: int,
+            desc: str,
+            assay: bool,
+        ) -> dict:
         """
         Create a ticket issue
         Inputs:
@@ -373,6 +385,7 @@ class Jira:
 
         return response.json()
 
+
     def make_transition(self, issue_id, transition_id):
         """
         Make a transition for an issue
@@ -385,7 +398,6 @@ class Jira:
         }
 
         payload = json.dumps({"transition": {"id": transition_id}})
-
         response = self.http.post(url, data=payload, headers=headers, auth=self.auth)
 
         if response.status_code == 204:
@@ -393,18 +405,19 @@ class Jira:
         else:
             return response.text
 
+
     def delete_issue(self, issue_id):
         """
         Delete an issue
         """
         url = f"{self.api_url}/api/3/issue/{issue_id}"
-
         response = requests.request("DELETE", url, auth=self.auth)
 
         if response.status_code == 204:
             return "Request successful"
         else:
             return response.text
+
 
     def get_available_transitions(self, issue_id):
         """

--- a/bin/jira.py
+++ b/bin/jira.py
@@ -1,9 +1,11 @@
 import json
+from time import sleep
+from typing import Union
+
 import requests
 from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
 from urllib3.util import Retry
-from typing import Union
 
 
 class Assignee(object):
@@ -399,7 +401,7 @@ class Jira:
 
         payload = json.dumps({"transition": {"id": transition_id}})
         response = self.http.post(url, data=payload, headers=headers, auth=self.auth)
-
+        sleep(1)  # add tiny delay to let Jira catch up on the back end
         if response.status_code == 204:
             return "Request successful"
         else:

--- a/bin/util.py
+++ b/bin/util.py
@@ -144,7 +144,7 @@ def post_message_to_slack(
                     f"{duration.days % 7} days ago\n"
                 )
             elif (
-                int(duration.days) > int(n_weeks * 7)
+                int(duration.days) >= int(n_weeks * 7)
             ) and (
                 status.upper().replace('_', ' ') not in jira_delete_status
             ):
@@ -160,7 +160,6 @@ def post_message_to_slack(
                     f">{duration.days // 7} weeks "
                     f"{duration.days % 7} days ago\n"
                 )
-                data_count += 1
             else:
                 # runs have closed Jira ticket status, should have been
                 # pre-filtered before here => log it to check for in future

--- a/bin/util.py
+++ b/bin/util.py
@@ -200,7 +200,7 @@ def post_message_to_slack(
 
     text_data = "\n".join(final_msg)
 
-    deletion = today + dt.timedelta(days=2).strftime("%d %b %Y")
+    deletion = (today + dt.timedelta(days=2)).strftime("%d %b %Y")
 
     human_readable_used = sizeof_fmt(gused)
     human_readable_total = sizeof_fmt(gtotal)

--- a/bin/util.py
+++ b/bin/util.py
@@ -75,7 +75,7 @@ def post_message_to_slack(
 
     # allowed states for Jira tickets to be in for automated deletion
     jira_delete_status = [
-        "ALL_SAMPLES_RELEASED",
+        "ALL SAMPLES RELEASED",
         "DATA CANNOT BE PROCESSED",
         "DATA CANNOT BE RELEASED"
     ]
@@ -143,7 +143,11 @@ def post_message_to_slack(
                     f">{duration.days // 7} weeks "
                     f"{duration.days % 7} days ago\n"
                 )
-            elif duration.days > n_weeks * 7 and status.upper() not in jira_delete_status:
+            elif (
+                int(duration.days) > int(n_weeks * 7)
+            ) and (
+                status.upper().replace('_', ' ') not in jira_delete_status
+            ):
                 # run is old enough to be deleted but ticket
                 # not in done state => alert us
                 final_msg.append(
@@ -402,6 +406,7 @@ def read_or_new_pickle(path: str) -> dict:
     Returns:
         dict: the stored pickle dict
     """
+    log.info(f"Reading from pickle file: {path}")
     if os.path.isfile(path):
         with open(path, "rb") as f:
             pickle_dict = pickle.load(f)

--- a/bin/util.py
+++ b/bin/util.py
@@ -337,8 +337,8 @@ def check_project_directory(directory: str) -> bool:
 
 def get_describe_data(project: str) -> list:
     """
-    Function to see if there is 002 project
-    and its describe data
+    Function to see if there is 002 project and its describe data
+
     Input:
         project: text
     Return:
@@ -351,7 +351,7 @@ def get_describe_data(project: str) -> list:
         )
     )
 
-    return projects[0] if projects else []
+    return projects[0] if projects else {}
 
 
 def read_or_new_pickle(path: str) -> dict:
@@ -402,13 +402,23 @@ def get_weekday(date: dt.datetime, day: int, forward: bool = True):
     return date
 
 
-def get_runs(seqs: list, gene_path: str, log_path: str):
+def get_runs(seqs: list, genetic_dir: str, log_path: str):
     """
-    Function to check overlap between genetic_dir and log_dir
+    Function to check overlap between genetic_dir (where the sequencing
+    runs are written to) and log_dir (the logs of dx-streaming-upload)
+
     Input:
         seqs: list of sequencers
         genetic_dir: path to /genetics
         log_dir: path to all log files
+
+    Returns:
+        genetic_directory : list
+            list of identified run directories
+        logs_directory : list
+            list of log files identified
+        tmp_seq : dict
+            mapping of run directory to sequencer ID it came from
     """
     genetic_directory = []
     logs_directory = []
@@ -418,7 +428,7 @@ def get_runs(seqs: list, gene_path: str, log_path: str):
         log.info(f"Loop through {sequencer} started")
 
         # Defining gene and log directories
-        gene_dir = f"{gene_path}/{sequencer}"
+        gene_dir = f"{genetic_dir}/{sequencer}"
         logs_dir = f"{log_path}/{sequencer}"
 
         # list files in directories

--- a/bin/util.py
+++ b/bin/util.py
@@ -1,11 +1,11 @@
 import collections
 import datetime as dt
-import dxpy as dx
 import json
 import os
 import pickle
 import requests
 
+import dxpy as dx
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 from dateutil.relativedelta import relativedelta

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
-import os
-import sys
-import pickle
-from datetime import datetime
-import collections
-import shutil
 import argparse
+import collections
+from datetime import datetime
+import os
+import pickle
+import shutil
+import sys
+from types import SimpleNamespace
 
 from bin.util import (
     post_message_to_slack,
@@ -37,73 +38,467 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def get_env_variables():
+    """
+    Get required environment variables for running
+
+    Returns
+    -------
+    SimpleNamespace
+        mapping of key names to selected environment variables
+
+    Raises
+    ------
+    AssertionError
+        Raised if one or more variables missing
+    """
+    env_variable_mapping = {
+        "slack_token": "SLACK_TOKEN",
+        "debug": "ANSIBLE_DEBUG",
+        "server_testing": "ANSIBLE_TESTING",
+        "genetics_dir": "ANSIBLE_GENETICDIR",
+        "logs_dir": "ANSIBLE_LOGSDIR",
+        "ansible_week": "ANSIBLE_WEEK",
+        "pickle_path": "ANSIBLE_PICKLE_PATH",
+        "dnanexus_token": "DNANEXUS_TOKEN",
+        "jira_token": "JIRA_TOKEN",
+        "jira_email": "JIRA_EMAIL",
+        "jira_api_url": "JIRA_API_URL",
+        "slack_url": "SLACK_NOTIFY_URL",
+        "jira_project_id": "JIRA_PROJECT_ID",
+        "jira_reporter_id": "JIRA_REPORTER_ID"
+    }
+
+    selected_env = SimpleNamespace()
+    missing = []
+
+    for k, v in env_variable_mapping.items():
+        if not os.environ.get(v):
+            missing.append(v)
+        else:
+            selected_env.k = os.environ.get(v)
+
+    assert not missing, (
+        f"Error - missing one or more environment variables "
+        f"{', '.join(missing)}"
+    )
+
+    return selected_env
+
+
+def check_for_deletion(
+        seqs,
+        genetics_dir,
+        logs_dir,
+        ansible_week,
+        server_testing,
+        slack_token,
+        pickle_file,
+        debug,
+        jira_assay,
+        jira_url,
+        jira
+
+    ):
+    """
+    Check for runs to delete, will be called every Monday and check for
+    runs that are over X weeks old
+
+    Inputs
+    ------
+    seqs : list
+        list of sequencer IDs to check runs against
+    genetics_dir : str
+        parent path to run directories
+    logs_dir : str
+        parent path to dx-streaming-upload log directory
+    ansible_week : int
+        number of weeks at which to automatically delete a run
+    server_testing : bool(?)
+    slack_token : str
+        Slack API token
+    pickle_file : str
+        name of pickle file to write runs to delete to
+    debug : bool
+        If running in debug
+    jira_assay : list
+        list of Jira assay codes we automatically delete runs for
+    jira_url : ?
+
+    jira
+
+    Outputs
+    -------
+    file
+        pickle file with details on runs to automatically delete store in
+    """
+    to_delete = collections.defaultdict(dict)  # to store runs marked for deletion
+    manual_review = []  # to store runs that need manually reviewing
+
+    genetic_directory, logs_directory, tmp_seq = get_runs(
+        seqs, genetics_dir, logs_dir
+    )
+
+    # get /genetic disk usage stat
+    init_usage = shutil.disk_usage(genetics_dir)
+    today = datetime.today()
+
+    # Get the duplicates between two directories /genetics & /var/log/ =>
+    # valid sequencing runs that dx-streaming-upload has uploaded
+    uploaded_runs = set(genetic_directory) & set(logs_directory)
+
+    log.info(f"Found {len(uploaded_runs)} run directories")
+
+    for run in uploaded_runs:
+        # check if proj in staging52
+        uploaded: bool = check_project_directory(run)
+
+        # get the sequencer the proj is in
+        seq = tmp_seq[run]
+
+        # get run size
+        run_path = f"{genetics_dir}/{seq}/{run}"
+        run_size = get_size(run_path)
+
+        # get 002 project describe data
+        project_data = get_describe_data(run)
+
+        if project_data:
+            # found 002 project => generate link
+            trimmed_id = project_data.get(
+                'describe', '').get('id', '').replace('project-', '')
+            url = (
+                f"https://platform.dnanexus.com/panx/projects/"
+                f"{trimmed_id}/data"
+            )
+        else:
+            url = "NA"
+
+        # get run created date
+        created_date = get_date(os.path.getmtime(run_path))
+        created_on = created_date.strftime("%Y-%m-%d")
+        duration = get_duration(today, created_date)
+
+        # check age of run
+        old_enough = check_age(created_date, today, ansible_week)
+
+        # get run Jira details
+        assay, status, key = jira.get_issue_detail(run, server_testing)
+
+        delete = False
+
+        if not old_enough:
+            # run less than defined no. weeks to wait to delete => skip
+            log.info(
+                f"{project} {created_on} ::: {round(duration.days / 7, 2)}"
+                f" weeks - not old enough to delete"
+            )
+
+            continue
+
+        if uploaded:
+            # found uploaded run in StagingArea52 => check it is has
+            # been processed and Jira state
+            if (
+                project_data and
+                status.upper() == "ALL_SAMPLES_RELEASED"
+                and assay in jira_assay
+            ):
+                # run has been released and is an assay we automatically
+                # delete => flag for deletion
+                log.info(
+                    f"{project} {created_on} ::: {round(duration.days / 7, 2)}"
+                    f" weeks - flagged for deletion"
+                )
+
+                delete = True
+            elif (
+                status.upper() in [
+                    "DATA CANNOT BE PROCESSED", "DATA CANNOT BE RELEASED"
+                ] and
+                assay in jira_assay
+            ):
+                # run uploaded and is an assay we automatically delete
+                # but either can't be processed or was processed but not
+                # released (i.e. low quality) => flag these to delete
+                log.info(
+                    f"{project} {created_on} ::: {round(duration.days / 7, 2)}"
+                    f" weeks - uploaded but not processed / released - "
+                    "flagged for deletion"
+                )
+                delete = True
+
+
+        if delete:
+            # enough criteria passed above to delete
+            to_delete[run] = {
+                "seq": seq,
+                "status": status,
+                "key": key,
+                "assay": assay,
+                "created": created_on,
+                "duration": round(duration.days / 7, 2),
+                "old_enough": old_enough,
+                "url": url,
+                "size": run_size,
+            }
+        else:
+            # run old enough to delete but not passed checks => flag
+            # up to review manually
+            log.info(
+                f"{project} {created_on} ::: {round(duration.days / 7, 2)}"
+                f" weeks - run not passed checks - flag for manual review"
+            )
+
+            manual_review[run] = {
+                "seq": seq,
+                "status": status,
+                "key": key,
+                "assay": assay,
+                "created": created_on,
+                "duration": round(duration.days / 7, 2),
+                "old_enough": old_enough,
+                "url": url,
+                "size": run_size,
+            }
+
+    if to_delete:
+        # found more than one run to delete
+        log.info("Writing runs flagged to delete into pickle file")
+        with open(pickle_file, "wb") as f:
+            pickle.dump(to_delete, f)
+
+    if manual_review:
+        # found more than one run requiring manually reviewing
+        post_message_to_slack(
+            channel="egg-alerts",
+            token=slack_token,
+            data=manual_review,
+            debug=debug,
+            usage=init_usage,
+            today=today,
+            jira_url=jira_url,
+            action="manual",
+        )
+
+
+def delete_runs(
+        ANSIBLE_PICKLE,
+        genetics_dir,
+        jira_project_id,
+        jira_reporter_id,
+        slack_token,
+        server_testing,
+        debug
+    ):
+    """
+    Delete the specified runs in the pickle file
+
+    Inputs
+    ------
+    ANSIBLE_PICKLE : str
+
+    genetics_dir : str
+
+    jira_project_id : str
+
+    jira_reporter_id : str
+
+    slack_token : str
+
+    server_testing : bool
+
+    debug : bool
+
+    """
+    deleted_details = dict()
+    deleted_runs = []
+
+    jira_delete_status = [
+        "ALL_SAMPLES_RELEASED",
+        "DATA CANNOT BE PROCESSED",
+        "DATA CANNOT BE RELEASED"
+    ]
+
+    # get /genetic disk usage stat
+    init_usage = shutil.disk_usage(genetics_dir)
+    today = datetime.today()
+
+    runs_pickle = read_or_new_pickle(ANSIBLE_PICKLE)
+
+    if not runs_pickle:
+        # pickle file empty or doesn't exist => exit
+        log.info("pickle file empty or doesn't exist. Exiting now.")
+        sys.exit(0)
+
+    for run, values in runs_pickle.items():
+        # last check to see if Jira status is still valid for deleting
+        _, status, _ = jira.get_issue_detail(run, server_testing)
+
+        seq = values["seq"].strip()
+        key = values["key"].strip()
+        assay = values["assay"].strip()
+        size = values["size"].strip()
+
+        if status.upper() not in jira_delete_status:
+            log.info(
+                f"Jira status not valid to delete ({status}) - skipping "
+                f"deletion of {genetics_dir}/{seq}/{run}")
+            continue
+
+        deleted_runs.append(f"{genetics_dir}/{seq}/{run} {today}\n")
+
+        try:
+            log.info(f"DELETING {genetics_dir}/{seq}/{run}")
+            shutil.rmtree(f"{genetics_dir}/{seq}/{run}")
+
+            deleted_details[run] = {
+                "seq": seq,
+                "status": status,
+                "key": key,
+                "assay": assay,
+                "size": size
+            }
+        except OSError as err:
+            log.error(
+                f"Error in deleting {genetics_dir}/{seq}/{run}. Stopping "
+                "further automatic deletion"
+            )
+
+            clear_memory(ANSIBLE_PICKLE)
+
+            msg = (
+                ":warning:"
+                f"ANSIBLE-MONITORING: ERROR with deleting `{run}`."
+                " Stopping further automatic deletion."
+                f"\n```{err}```"
+            )
+
+            post_simple_message_to_slack(
+                msg,
+                "egg-alerts",
+                slack_token,
+                debug,
+            )
+
+            sys.exit("END SCRIPT")
+
+    if deleted_details:
+        # something deleted => create Jira ticket to acknowledge
+
+        # get after deletion disk usage
+        post_usage = shutil.disk_usage(genetics_dir)
+        # make datetime into str type
+        jira_date = today.strftime("%d/%m/%Y")
+
+        # format disk usage for jira issue description
+        init_total = round(init_usage[0] / 1024 / 1024 / 1024, 2)
+        init_used = round(init_usage[1] / 1024 / 1024 / 1024, 2)
+        init_percent = round((init_usage[1] / init_usage[0]) * 100, 2)
+
+        p_total = round(post_usage[0] / 1024 / 1024 / 1024, 2)
+        p_used = round(post_usage[1] / 1024 / 1024 / 1024, 2)
+        p_percent = round((post_usage[1] / post_usage[0]) * 100, 2)
+
+        # format deleted run for issue description
+        jira_data = [
+            "{} in /genetics/{}".format(k, v["seq"]) for k, v in tmp_delete.items()
+        ]
+
+        # description body
+        body = "\n".join(jira_data)
+
+        desc = f"Runs deleted on {jira_date}\n"
+
+        # all disk space data
+        disk_usage = (
+            "\n/genetics disk usage before: "
+            f"{init_used} / {init_total} {init_percent}%"
+            "\n/genetics disk usage after: "
+            f"{p_used} / {p_total} {p_percent}%"
+        )
+
+        desc += body + disk_usage
+
+        # create Jira issue
+        # issue type for acknowledgement 10124
+        # helpdesk 10042 for debug 10040 for prod
+
+        log.info("Creating Jira acknowledgement issue")
+        issue_title = f"{jira_date} Automated deletion of runs from ansible server"
+        response = jira.create_issue(
+            summary=issue_title,
+            issue_id=10124,
+            project_id=jira_project_id,
+            reporter_id=jira_reporter_id,
+            priority_id=3,
+            desc=desc,
+            assay=False,
+        )
+
+        if "id" in response:
+            # log the raised issue key for reference in future
+            issue_key = response["key"]
+            log.info(f"{issue_key} {jira_project_id}")
+        else:
+            # if jira ticket creation issue
+            # send msg to Slack - stop script
+            err_msg = response["errors"]
+            msg = ":warning:" "ANSIBLE-MONITORING: ERROR with creating Jira ticket!"
+            msg += f"\n`{err_msg}`"
+
+            post_simple_message_to_slack(
+                msg,
+                "egg-alerts",
+                slack_token,
+                debug,
+            )
+
+            log.error(response)
+            sys.exit("END SCRIPT")
+
+
+    # write to /log just for own record
+    with open("/log/monitoring/ansible_delete.txt", "a") as f:
+        for deleted in deleted_runs:
+            f.write(deleted)
+
+
+
 def main():
     args = parse_arguments()
-
-    # importing env variables
-    try:
-        SLACK_TOKEN = os.environ["SLACK_TOKEN"]
-        DEBUG = os.environ.get("ANSIBLE_DEBUG", False)
-        SERVER_TESTING = os.environ.get("ANSIBLE_TESTING", False)
-
-        GENETIC_DIR = os.environ["ANSIBLE_GENETICDIR"]
-        LOGS_DIR = os.environ["ANSIBLE_LOGSDIR"]
-        ANSIBLE_WEEK = int(os.environ["ANSIBLE_WEEK"])
-        PICKLE_PATH = os.environ["ANSIBLE_PICKLE_PATH"]
-
-        DNANEXUS_TOKEN = os.environ["DNANEXUS_TOKEN"]
-
-        JIRA_TOKEN = os.environ["JIRA_TOKEN"]
-        JIRA_EMAIL = os.environ["JIRA_EMAIL"]
-        JIRA_ASSAY = [a.strip() for a in os.environ["ANSIBLE_JIRA_ASSAY"].split(",")]
-        JIRA_API_URL = os.environ["JIRA_API_URL"]
-        JIRA_SLACK_URL = os.environ["SLACK_NOTIFY_JIRA_URL"]
-        JIRA_PROJECT_ID = os.environ["JIRA_PROJECT_ID"]
-        JIRA_REPORTER_ID = os.environ["JIRA_REPORTER_ID"]
-
-        SEQS = [x.strip() for x in os.environ["ANSIBLE_SEQ"].split(",")]
-    except KeyError as err:
-        log.error(f"Failed to import env {err}")
-
-        message = f":warning:ANSIBLE-MONITORING: Failed to import env {err}"
-        post_simple_message_to_slack(
-            message,
-            "egg-alerts",
-            SLACK_TOKEN,
-            DEBUG,
-        )
-        sys.exit("END SCRIPT")
+    env = get_env_variables()
 
     # log debug status
-    if DEBUG:
-        log.info("Running in DEBUG mode")
-        ANSIBLE_PICKLE = f"{PICKLE_PATH}/ansible_dict.test.pickle"
+    if env.debug:
+        log.info("Running in debug mode")
+        env.pickle_path = f"{env.pickle_path}/ansible_dict.test.pickle"
     else:
         log.info("Running in PRODUCTION mode")
-        ANSIBLE_PICKLE = f"{PICKLE_PATH}/ansible_dict.pickle"
+        env.pickle_path = f"{env.pickle_path}/ansible_dict.pickle"
 
     # dxpy login
-    if not dx_login(DNANEXUS_TOKEN):
-        message = ":warning:ANSIBLE-MONITORING: ERROR with dxpy login!"
+    if not dx_login(env.dnanexus_token):
+        message = ":warning:ANSIBLE-RUN-MONITORING: ERROR with dxpy login!"
 
         post_simple_message_to_slack(
             message,
             "egg-alerts",
-            SLACK_TOKEN,
-            DEBUG,
+            env.slack_token,
+            env.debug,
         )
 
         sys.exit("END SCRIPT")
 
     # check if /genetics & /logs/dx-streaming-upload exist
-    if not directory_check([GENETIC_DIR, LOGS_DIR]):
+    if not directory_check([env.genetics_dir, env.logs_dir]):
         message = ":warning:ANSIBLE-MONITORING: ERROR with missing directory!"
 
         post_simple_message_to_slack(
             message,
             "egg-alerts",
-            SLACK_TOKEN,
-            DEBUG,
+            env.slack_token,
+            env.debug,
         )
 
         sys.exit("END SCRIPT")
@@ -112,394 +507,47 @@ def main():
     today = datetime.today()
     log.info(today)
 
-    # read memory in /var/log/monitoring
-    ansible_pickle = read_or_new_pickle(ANSIBLE_PICKLE)
-    runs = ansible_pickle.keys()
-
-    jira = Jira(JIRA_TOKEN, JIRA_EMAIL, JIRA_API_URL, DEBUG)
-
-    # get /genetic disk usage stat
-    init_usage = shutil.disk_usage(GENETIC_DIR)
-
-    if today.day == 1:
-        # run deletion on the 1st
-        tmp_delete = collections.defaultdict(dict)
-        if runs:
-            for run in runs:
-                # last check to see if status is still
-                # ALL-SAMPLES-RELEASED
-                _, status, _ = jira.get_issue_detail(run, SERVER_TESTING)
-
-                seq = ansible_pickle[run]["seq"]
-                key = ansible_pickle[run]["key"]
-                assay = ansible_pickle[run]["assay"]
-                size = ansible_pickle[run]["size"]
-
-                if status.upper() != "ALL SAMPLES RELEASED":
-                    log.info(f"SKIP {GENETIC_DIR}/{seq}/{run}")
-                    continue
-
-                assert seq.strip(), "sequencer is empty"
-                assert run.strip(), "run ID is empty"
-
-                try:
-                    log.info(f"DELETING {GENETIC_DIR}/{seq}/{run}")
-                    shutil.rmtree(f"{GENETIC_DIR}/{seq}/{run}")
-
-                    tmp_delete[run]["seq"] = seq
-                    tmp_delete[run]["status"] = status
-                    tmp_delete[run]["key"] = key
-                    tmp_delete[run]["assay"] = assay
-                    tmp_delete[run]["size"] = size
-
-                    # write to /log just for own record
-                    with open("/log/monitoring/ansible_delete.txt", "a") as f:
-                        f.write(f"{GENETIC_DIR}/{seq}/{run} {today}" + "\n")
-
-                except OSError as e:
-                    # if deletion failed
-                    # clear memory & end script
-                    log.error(e)
-                    clear_memory(ANSIBLE_PICKLE)
-
-                    msg = (
-                        ":warning:"
-                        f"ANSIBLE-MONITORING: ERROR with deleting `{run}`."
-                        " Stopping further automatic deletion."
-                        f"\n```{e}```"
-                    )
-
-                    post_simple_message_to_slack(
-                        msg,
-                        "egg-alerts",
-                        SLACK_TOKEN,
-                        DEBUG,
-                    )
-
-                    sys.exit("END SCRIPT")
-
-        if tmp_delete:
-            # something has been deleted
-            # create a Jira ticket for acknowledgement
-
-            # get after deletion disk usage
-            post_usage = shutil.disk_usage(GENETIC_DIR)
-            # make datetime into str type
-            jira_date = today.strftime("%d/%m/%Y")
-
-            # format disk usage for jira issue description
-            init_total = round(init_usage[0] / 1024 / 1024 / 1024, 2)
-            init_used = round(init_usage[1] / 1024 / 1024 / 1024, 2)
-            init_percent = round((init_usage[1] / init_usage[0]) * 100, 2)
-
-            p_total = round(post_usage[0] / 1024 / 1024 / 1024, 2)
-            p_used = round(post_usage[1] / 1024 / 1024 / 1024, 2)
-            p_percent = round((post_usage[1] / post_usage[0]) * 100, 2)
-
-            # format deleted run for issue description
-            jira_data = [
-                "{} in /genetics/{}".format(k, v["seq"]) for k, v in tmp_delete.items()
-            ]
-
-            # description body
-            body = "\n".join(jira_data)
-
-            desc = f"Runs deleted on {jira_date}\n"
-
-            # all disk space data
-            disk_usage = (
-                "\n/genetics disk usage before: "
-                f"{init_used} / {init_total} {init_percent}%"
-                "\n/genetics disk usage after: "
-                f"{p_used} / {p_total} {p_percent}%"
-            )
-
-            desc += body + disk_usage
-
-            # create Jira issue
-            # issue type for acknowledgement 10124
-            # helpdesk 10042 for debug 10040 for prod
-
-            log.info("Creating Jira acknowledgement issue")
-            issue_title = f"{jira_date} Automated deletion of runs from ansible server"
-            response = jira.create_issue(
-                summary=issue_title,
-                issue_id=10124,
-                project_id=JIRA_PROJECT_ID,
-                reporter_id=JIRA_REPORTER_ID,
-                priority_id=3,
-                desc=desc,
-                assay=False,
-            )
-
-            if "id" in response:
-                # log the raised issue key for reference in future
-                issue_key = response["key"]
-                log.info(f"{issue_key} {JIRA_PROJECT_ID}")
-            else:
-                # if jira ticket creation issue
-                # send msg to Slack - stop script
-                err_msg = response["errors"]
-                msg = ":warning:" "ANSIBLE-MONITORING: ERROR with creating Jira ticket!"
-                msg += f"\n`{err_msg}`"
-
-                post_simple_message_to_slack(
-                    msg,
-                    "egg-alerts",
-                    SLACK_TOKEN,
-                    DEBUG,
-                )
-
-                log.error(response)
-                sys.exit("END SCRIPT")
-
-    elif (today.day >= 17 and today.day < 24) or args.notification:
-        # if today is nearing 24th
-        alert_day = get_next_month(today, 24)
-
-        # check if alert day falls on weekend
-        if alert_day.isoweekday() in [6, 7] or args.notification:
-            # if so, get the coming Friday
-            friday = get_weekday(alert_day, 5, False)
-
-            if today == friday or args.notification:
-                # send alert about deletion
-                log.info(today)
-                if runs:
-                    post_message_to_slack(
-                        channel="egg-alerts",
-                        token=SLACK_TOKEN,
-                        data=ansible_pickle,
-                        debug=DEBUG,
-                        usage=init_usage,
-                        today=today,
-                        jira_url=JIRA_SLACK_URL,
-                        action="delete",
-                    )
-                else:
-                    log.info("NO RUNS IN MEMORY DETECTED")
-            else:
-                pass
-    elif today.day == 24 and today.isoweekday in [6, 7]:
-        # today is 24th but is a weekend, don't send alert
-        # because we have already sent one on Friday
-        pass
-    elif today.day == 24 or args.notification:
-        # today is the 24th and not a weekend or --notification tag
-        if runs:
-            post_message_to_slack(
-                channel="egg-alerts",
-                token=SLACK_TOKEN,
-                data=ansible_pickle,
-                debug=DEBUG,
-                usage=init_usage,
-                today=today,
-                jira_url=JIRA_SLACK_URL,
-                action="delete",
-            )
-        else:
-            log.info("NO RUNS IN MEMORY DETECTED")
-    else:
-        # today is 25th to 31th
-        pass
-
-    temp_pickle = collections.defaultdict(dict)  # to store runs marked for deletion
-    temp_stale = collections.defaultdict(dict)  # to store stale run
-    temp_manual_intervention = []  # to store runs that need manual intervention
-
-    genetic_directory, logs_directory, tmp_seq = get_runs(SEQS, GENETIC_DIR, LOGS_DIR)
-
-    # Get the duplicates between two directories /genetics & /var/log/
-    temp_duplicates = set(genetic_directory) & set(logs_directory)
-
-    log.info(f"Number of overlap files: {len(temp_duplicates)}")
-
-    # for each project, we check if it exists on DNANexus
-    for project in list(temp_duplicates):
-        # check if proj in staging52
-        uploaded: bool = check_project_directory(project)
-
-        # get the sequencer the proj is in
-        seq = tmp_seq[project]
-
-        # get project size
-        run_path = f"{GENETIC_DIR}/{seq}/{project}"
-        run_size = get_size(run_path)
-
-        # get 002 proj describe data
-        project_data = get_describe_data(project)
-
-        # get run created date
-        created_date = get_date(os.path.getmtime(run_path))
-        created_on = created_date.strftime("%Y-%m-%d")
-        duration = get_duration(today, created_date)
-
-        # check age of run
-        old_enough = check_age(created_date, today, ANSIBLE_WEEK)
-
-        # get proj jira details
-        assay, status, key = jira.get_issue_detail(project, SERVER_TESTING)
-
-        if project_data and uploaded:
-            # found the 002 project & found in staging52
-
-            data = project_data["describe"]
-            trimmed_id = data["id"].replace("project-", "")
-            DX_URL = "https://platform.dnanexus.com/panx/projects"
-
-            if old_enough:
-                # run is old enough meaning
-                # been there for more than ANSIBLE_WEEK
-
-                if status.upper() == "ALL SAMPLES RELEASED" and assay in JIRA_ASSAY:
-                    # Jira ticket is ALL SAMPLES RELEASED
-                    # and assay in listed assays
-
-                    # will be marked for deletion
-                    temp_pickle[project] = {
-                        "seq": seq,
-                        "status": status,
-                        "key": key,
-                        "assay": assay,
-                        "created": created_on,
-                        "duration": round(duration.days / 7, 2),
-                        "old_enough": old_enough,
-                        "url": f"{DX_URL}/{trimmed_id}/data",
-                        "size": run_size,
-                    }
-
-                    log.info(
-                        "{} {} ::: {} weeks PASS".format(
-                            project,
-                            created_on,
-                            duration.days / 7,
-                        )
-                    )
-
-                    continue
-                else:
-                    # Jira status not 'ALL SAMPLES RELEASED'
-                    # or assay incorrect
-                    log.info(
-                        "{} {} ::: {} weeks FAILED JIRA".format(
-                            project,
-                            created_on,
-                            round(duration.days / 7, 2),
-                        )
-                    )
-
-                    if key is None or assay in JIRA_ASSAY:
-                        # have 002 project and old enough
-                        # Have no Jira ticket
-                        # or Jira ticket not All RELEASED
-
-                        # check if stale
-                        temp_stale[project] = {
-                            "seq": seq,
-                            "status": status,
-                            "key": key,
-                            "assay": assay,
-                            "created": created_on,
-                            "duration": round(duration.days / 7, 2),
-                            "old_enough": old_enough,
-                            "url": f"{DX_URL}/{trimmed_id}/data",
-                            "size": run_size,
-                        }
-
-                    continue
-            else:
-                # runs not old enough meaning
-                # runs have not been there for longer
-                # than ANSIBLE_WEEK
-                # shouldn't be marked for deletion
-
-                log.info(
-                    "{} {} ::: {} weeks NOT OLD".format(
-                        project, created_on, round(duration.days / 7, 2)
-                    )
-                )
-
-                if key is None or assay in JIRA_ASSAY:
-                    # have 002 project & not old enough
-                    # Jira ticket - no idea
-
-                    # check if stale
-                    temp_stale[project] = {
-                        "seq": seq,
-                        "status": status,
-                        "key": key,
-                        "assay": assay,
-                        "created": created_on,
-                        "duration": round(duration.days / 7, 2),
-                        "old_enough": old_enough,
-                        "url": f"{DX_URL}/{trimmed_id}/data",
-                        "size": run_size,
-                    }
-
-                continue
-        else:
-            # either no 002 project found
-            # or not uploaded to staging52
-
-            if not uploaded:
-                log.info(
-                    f"{project} {created_on} ::: {round(duration.days / 7, 2)}"
-                    " weeks FAILED - NOT ON STAGING52"
-                )
-            elif not project_data:
-                log.info(
-                    f"{project} {created_on} ::: {round(duration.days / 7, 2)}"
-                    " weeks FAILED - NO 002 PROJECT"
-                )
-
-            # check if run is more than ANSIBLE_WEEK weeks - time for manual intervention
-            if check_age(created_date, today, ANSIBLE_WEEK):
-                temp_manual_intervention.append(
-                    f"`{run_path}` :: {round(duration.days / 7, 2)} weeks\n"
-                    f"<{JIRA_SLACK_URL}{key}|{status}>\n"
-                    "No 002 project found"
-                    if not project_data
-                    else "Not on staging52"
-                )
-
-            continue
-
-    log.info(f"Stale runs to check: {len(temp_stale)}")
-    log.info(f"{len(temp_pickle.keys())} marked for deletion")
-
-    if today.day < 24:
-        # we send countdown / alert on 24th
-        # so anything after 24th shouldn't be considered
-        # for deletion until the next cycle
-
-        log.info("Writing into pickle file")
-        with open(ANSIBLE_PICKLE, "wb") as f:
-            pickle.dump(temp_pickle, f)
-
-    # send about stale run
-    post_message_to_slack(
-        channel="egg-logs",
-        token=SLACK_TOKEN,
-        data=temp_stale,
-        debug=DEBUG,
-        usage=init_usage,
-        today=today,
-        jira_url=JIRA_SLACK_URL,
-        action="stale",
+    jira = Jira(
+        token=env.jira_token,
+        email=env.jira_email,
+        api_url=env.jira_api_url,
+        debug=env.debug
     )
 
-    # send about manual intervention
-    if temp_manual_intervention:
-        post_message_to_slack(
-            channel="egg-logs",
-            token=SLACK_TOKEN,
-            data=temp_manual_intervention,
-            debug=DEBUG,
-            usage=init_usage,
-            today=today,
-            jira_url=JIRA_SLACK_URL,
-            action="manual",
+
+    if today.isoweekday == 1:
+        # Monday => check for runs to delete and send upcoming alert
+        check_for_deletion(
+            seqs=env.seqs,
+            genetics_dir=env.genetics_dir,
+            logs_dir=env.ogs_dir,
+            ansible_week=env.ansible_week,
+            server_testing=env.server_testing,
+            slack_token=env.slack_token,
+            pickle_file=env.pickle_file,
+            debug=env.debug,
+            jira=jira,
+            jira_assay=env.jira_assay,
+            jira_url=env.jira_url
         )
+    elif today.isoweekday == 3:
+        # Wednesday => run the deletion
+        delete_runs(
+            ANSIBLE_PICKLE=env.pickle_file,
+            genetics_dir=env.genetics_dir,
+            jira_project_id=env.jira_project_id,
+            jira_reporter_id=env.jira_reporter_id,
+            slack_token=env.slack_token,
+            server_testing=env.server_testing,
+            debug=env.debug
+        )
+
+    else:
+        # other day of the week => do nothing
+        log.info(
+            f"Today is not Monday or Wednesday - nothing to do"
+        )
+        sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -93,7 +93,18 @@ def check_for_deletion(
     ):
     """
     Check for runs to delete, will be called every Monday and check for
-    runs that are over X weeks old
+    runs that can be automatically deleted against the following criteria:
+
+        - over X weeks old (defined from config)
+        - have data in StagingArea52 DNAnexus project
+        - have a 002 project
+        - have a Jira ticket with stats in one of the following:
+            - ALL_SAMPLES_RELEASED
+            - DATA CANNOT BE PROCESSED
+            - DATA CANNOT BE RELEASED
+
+    Any runs that are old enough but do not meet the above criteria will be
+    added to a Slack alert for manual review.
 
     Inputs
     ------
@@ -114,9 +125,10 @@ def check_for_deletion(
         If running in debug
     jira_assay : list
         list of Jira assay codes we automatically delete runs for
-    jira_url : ?
-
-    jira
+    jira_url : str
+        URL endpoint for our Jira
+    jira : jira.Jira
+        Jira class object for querying Jira
 
     Outputs
     -------
@@ -284,7 +296,8 @@ def delete_runs(
         jira
     ):
     """
-    Delete the specified runs in the pickle file
+    Delete the specified runs in the pickle file that have been
+    previously checked and flagged for automatic deletion
 
     Inputs
     ------

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from bin.jira import Jira
 log = get_logger("main log")
 
 
-def get_env_variables():
+def get_env_variables() -> SimpleNamespace:
     """
     Get required environment variables for running and store
     these in a NameSpace object
@@ -89,8 +89,7 @@ def check_for_deletion(
         jira_assay,
         jira_url,
         jira
-
-    ):
+    ) -> None:
     """
     Check for runs to delete, will be called every Monday and check for
     runs that can be automatically deleted against the following criteria:
@@ -294,7 +293,7 @@ def delete_runs(
         server_testing,
         debug,
         jira
-    ):
+    ) -> None:
     """
     Delete the specified runs in the pickle file that have been
     previously checked and flagged for automatic deletion

--- a/main.py
+++ b/main.py
@@ -348,7 +348,7 @@ def delete_runs(
 
     # allowed states for Jira tickets to be in for automated deletion
     jira_delete_status = [
-        "ALL_SAMPLES_RELEASED",
+        "ALL SAMPLES RELEASED",
         "DATA CANNOT BE PROCESSED",
         "DATA CANNOT BE RELEASED"
     ]
@@ -503,7 +503,12 @@ def delete_runs(
             sys.exit("END SCRIPT")
 
     # write to /log just for own record
-    with open("/log/monitoring/ansible_delete.txt", "a") as f:
+    if os.path.exists("/log/monitoring"):
+        log_file = "/log/monitoring/ansible_delete.txt"
+    else:
+        log_file = "ansible_delete.txt"
+
+    with open(log_file, "a") as f:
         for deleted in deleted_runs:
             f.write(deleted)
 

--- a/main.py
+++ b/main.py
@@ -383,7 +383,7 @@ def delete_runs(
         seq = values["seq"].strip()
         key = values["key"].strip()
         assay = values["assay"].strip()
-        size = values["size"].strip()
+        size = str(values["size"]).strip()
 
         if status.upper() not in jira_delete_status:
             log.info(

--- a/main.py
+++ b/main.py
@@ -145,9 +145,6 @@ def check_for_deletion(
     init_usage = shutil.disk_usage(genetics_dir)
     today = datetime.today()
 
-    print(f'TODAY IS {today.isoweekday()}')
-    print(today)
-
     # Get the duplicates between two directories /genetics & /var/log/ =>
     # valid sequencing runs that dx-streaming-upload has uploaded
     local_runs = sorted(set(genetic_directory) & set(logs_directory))
@@ -360,6 +357,15 @@ def delete_runs(
     init_usage = shutil.disk_usage(genetics_dir)
     today = datetime.today()
 
+    if today.isoweekday() != 3:
+        # today is not a Wednesday => don't do anything
+        log.info(
+            f"Today is {today.strftime('%A')} therefore no "
+            "deletion will be performed"
+        )
+
+        return
+
     runs_pickle = read_or_new_pickle(pickle_file)
 
     if not runs_pickle:
@@ -564,18 +570,17 @@ def main():
         jira_url=env.jira_url
     )
 
-    if today.isoweekday() == 3:
-        # Wednesday => run the deletion
-        delete_runs(
-            pickle_file=env.pickle_file,
-            genetics_dir=env.genetics_dir,
-            jira_project_id=env.jira_project_id,
-            jira_reporter_id=env.jira_reporter_id,
-            slack_token=env.slack_token,
-            server_testing=env.server_testing,
-            debug=env.debug,
-            jira=jira
-        )
+    delete_runs(
+        pickle_file=env.pickle_file,
+        genetics_dir=env.genetics_dir,
+        jira_project_id=env.jira_project_id,
+        jira_reporter_id=env.jira_reporter_id,
+        slack_token=env.slack_token,
+        server_testing=env.server_testing,
+        debug=env.debug,
+        jira=jira
+    )
+
 
 if __name__ == "__main__":
     log.info("STARTING SCRIPT")

--- a/monitor.py
+++ b/monitor.py
@@ -87,6 +87,7 @@ def get_env_variables() -> SimpleNamespace:
     selected_env.debug = (
         True if selected_env.debug.lower() == 'true' else False
     )
+    selected_env.ansible_week = int(selected_env.ansible_week)
 
     return selected_env
 

--- a/monitor.py
+++ b/monitor.py
@@ -312,7 +312,6 @@ def check_for_deletion(
     if manual_review and today.isoweekday() == 1:
         # found more than one run requiring manually reviewing, only
         # send alerts for these on a Monday morning to not get too spammy
-        print('posting slack')
         post_message_to_slack(
             channel="egg-test",
             token=slack_token,

--- a/monitor.py
+++ b/monitor.py
@@ -79,8 +79,11 @@ def get_env_variables() -> SimpleNamespace:
     )
 
     # fix required types
-    selected_env.seqs = selected_env.seqs.split(',')
-    selected_env.jira_assay = selected_env.jira_assay.split(',')
+    selected_env.seqs = [x.strip() for x in selected_env.seqs.split(',')]
+    selected_env.jira_assay = [
+        x.strip() for x in selected_env.jira_assay.split(',')
+    ]
+
     selected_env.server_testing = (
         True if selected_env.server_testing.lower() == 'true' else False
     )
@@ -406,8 +409,6 @@ def delete_runs(
                 f"deletion of {genetics_dir}/{seq}/{run}")
             continue
 
-        deleted_runs.append(f"{genetics_dir}/{seq}/{run} {today}\n")
-
         try:
             log.info(f"DELETING {genetics_dir}/{seq}/{run}")
             shutil.rmtree(f"{genetics_dir}/{seq}/{run}")
@@ -419,6 +420,9 @@ def delete_runs(
                 "assay": assay,
                 "size": size
             }
+
+            deleted_runs.append(f"{genetics_dir}/{seq}/{run} {today}\n")
+
         except OSError as err:
             log.error(
                 f"Error in deleting {genetics_dir}/{seq}/{run}. Stopping "

--- a/monitor.py
+++ b/monitor.py
@@ -529,7 +529,6 @@ def delete_runs(
 
 
 def main():
-    print('starting')
     env = get_env_variables()
 
     # log debug status

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -1,0 +1,340 @@
+"""
+Outline of end to end test to set up
+
+Runs with the following:
+    - 1 run under X weeks old
+        - these should be logged as not old enough and excluded
+    - Runs criteria that should be logged as error and flagged for manual review
+        - 1 run old enough but no data uploaded (shouldn't happen)
+        - 1 run run old enough and uploaded to stagingArea but no 002 project
+        - 1 run old enough, uploaded and 002 project but ticket not in right state
+    - 1 run that is old enough, uploaded, 002 project and ticket released
+        - flagged to delete
+    - 1 run that is old enough but has failed sequencing (ticket moved to
+        CANNOT BE PROCESSED)
+        - flagged to delete
+    1 run that is old enough and processed but likely QC failed (ticket
+        moved to CANNOT BE RELEASED)
+        - flagged to delete
+
+
+The above needs to be tested on following days of the week:
+    - Monday
+        - run deletion check, create pickle file of runs to delete
+        - should send alert of runs above with the given issues and
+            add these to the logs
+    - Wednesday
+        - should run the deletion against runs in the pickle file
+    - other days of the week
+        - should log issues but not send notifications
+
+"""
+from datetime import datetime
+from faker import Faker
+import os
+import shutil
+from unittest.mock import Mock, patch
+from dateutil.relativedelta import relativedelta
+
+from bin.jira import Jira
+from main import check_for_deletion, delete_runs
+
+
+# suffix for random naming of test runs
+SUFFIX = ""
+
+
+def create_test_run_directories() -> None:
+    """
+    Create test run data structure of 7 runs, all but the first we're
+    setting to be 'old enough' to delete (i.e. > ANSIBLE WEEKS old)
+    """
+    run_directories = [
+        f"seq1/run1_{SUFFIX}",
+        f"seq1/run2_{SUFFIX}",
+        f"seq1/run3_{SUFFIX}",
+        f"seq2/run4_{SUFFIX}",
+        f"seq2/run5_{SUFFIX}",
+        f"seq2/run6_{SUFFIX}",
+        f"seq2/run7_{SUFFIX}",
+    ]
+
+    os.makedirs("simulate_test", exist_ok=True)
+
+    today = datetime.today()
+
+    for idx, run in enumerate(run_directories, 2):
+        os.makedirs(f"simulate_test/{run}", exist_ok=True)
+
+        # set run age to be sequentially 1 week older starting at 2 weeks old
+        age = (today + relativedelta(weeks=-idx)).timestamp()
+        os.utime(f"simulate_test/{run}", (age, age))
+
+
+def create_test_logs() -> None:
+    """
+    Create required log files as generated from dx-streaming-upload, these
+    are used to checking if a directory is an monitored run directory
+    that we have started at least uploading
+    """
+    os.makedirs("simulate_test/logs/seq1", exist_ok=True)
+    os.makedirs("simulate_test/logs/seq2", exist_ok=True)
+
+    open(f"simulate_test/logs/seq1/run.run1_{SUFFIX}.lane.all.log", "w").close()
+    open(f"simulate_test/logs/seq1/run.run2_{SUFFIX}.lane.all.log", "w").close()
+    open(f"simulate_test/logs/seq1/run.run3_{SUFFIX}.lane.all.log", "w").close()
+    open(f"simulate_test/logs/seq2/run.run4_{SUFFIX}.lane.all.log", "w").close()
+    open(f"simulate_test/logs/seq2/run.run5_{SUFFIX}.lane.all.log", "w").close()
+    open(f"simulate_test/logs/seq2/run.run6_{SUFFIX}.lane.all.log", "w").close()
+    open(f"simulate_test/logs/seq2/run.run7_{SUFFIX}.lane.all.log", "w").close()
+
+
+def create_jira_tickets(jira) -> list:
+    """
+    Create required Jira tickets in required states for each run, this
+    will be as follows:
+        - run1 = not old enough -> NEW
+        - run2 = not uploaded -> NEW
+        - run3 = not processed -> New
+        - run4 = ticket not in right state -> On Hold
+        - run5 = released -> All Samples Released
+        - run6 = failed - not processed -> Data cannot be processed
+        - run7 = bad QC - not released -> Data cannot be released
+
+    Parameters
+    ----------
+    jira : jira.Jira
+        Jira object for Jira queries
+
+    # token : string
+    #     Jira API token
+    # email : string
+    #     Atlassian account email
+    # url : string
+    #     URL endpoint for test helpdesk
+    """
+    # mapping of run name to Jira issue state, these are numerical IDs
+    # associated to each state that we need to transition each ticket
+    # through, these can be found by going into the workflow edit mode
+    ticket_states = {
+        f"run1_{SUFFIX}": None,
+        f"run2_{SUFFIX}": None,
+        f"run3_{SUFFIX}": None,
+        f"run4_{SUFFIX}": None,
+        f"run5_{SUFFIX}": [31, 41, 21],  # Data released
+        f"run6_{SUFFIX}": [31, 61],      # Data cannot be processed
+        f"run7_{SUFFIX}": [31, 41, 71]   # Data cannot be released
+    }
+
+    created_issues = []
+
+    for run, state in ticket_states.items():
+        print(f"Creating Jira issue for {run}")
+        issue = jira.create_issue(
+            summary=run,
+            issue_id=10179,    # issue type
+            project_id=10042,  # EBHD id
+            reporter_id="5c0e8b8d53cd043c8c6149eb",
+            priority_id=3,
+            desc="Ticket created as part of simulated testing of automated deletion",
+            assay=True,
+        )
+
+        created_issues.append(issue)
+        if state:
+            for transition in state:
+                jira.make_transition(
+                    issue_id=issue['id'],
+                    transition_id=transition
+                )
+
+    return created_issues
+
+
+def create_run_suffix() -> None:
+    """
+    Generate a random word to append to run ID to get a random name,
+    dumping this into globals for every time it is called as too lazy
+    to go back and pass it around
+    """
+    fake = Faker()
+    global SUFFIX
+    SUFFIX='_'.join([fake.word() for x in range(3)])
+
+
+def delete_test_data() -> None:
+    """
+    Check for test data directories and pickle file to clean up
+    """
+    print("Deleting test data directories")
+    if os.path.exists('simulate_test'):
+        shutil.rmtree('simulate_test')
+
+
+def delete_pickle() -> None:
+    """
+    Delete the saved pickle file
+    """
+    if os.path.exists("check.pkl"):
+        os.remove("check.pkl")
+
+
+def delete_jira_tickets(jira, issues) -> None:
+    """
+    Delete Jira issue tickets we created as part of testing
+
+    Parameters
+    ----------
+    jira : jira.Jira
+        Jira object for Jira queries
+    ids : list
+        list of created Jira issue IDs
+    """
+    print("Deleting test Jira issues")
+    for issue in issues:
+        jira.delete_issue(issue['id'])
+
+
+def simulate_checking(jira, day) -> None:
+    """
+    Run everything to test the checking of runs for deletion
+
+    7 run states being simulated:
+
+        - 1 run under ANSIBLE_WEEK weeks old (will be ignored)
+        - 1 run old enough but no data uploaded (shouldn't happen)
+        - 1 run run old enough and uploaded to stagingArea but no 002 project
+        - 1 run old enough, uploaded and 002 project but ticket not in right state
+        - 1 run that is old enough, uploaded, 002 project and ticket released
+        - 1 run that failed sequencing and ticket at Data cannot be processed
+        - 1 run that failed QC and ticket at Data cannot be released
+
+    The last 3 of the above we expect to flag for deletion
+
+    Parameters
+    ----------
+    jira : jira.Jira
+        Jira object for Jira queries
+    day : int
+        day of the week we're checking for
+    """
+    print("Simulating checking of run directories")
+    # things we need to mock to not actually call external resources, since
+    # we're simulating 7 runs there will be 7 returns for each patch
+
+    # patch over the check for a run uploaded to StagingArea52
+    patch(
+        'main.check_run_uploaded',
+        side_effect=[True, False, True, True, True, True, True]
+    ).start()
+
+    # patch over check of 002 project with minimal required describe details
+    patch(
+        'main.get_describe_data',
+        side_effect=[
+            {'describe': {'id': 'project-xxx'}},
+            {},
+            {},
+            {'describe': {'id': 'project-xxx'}},
+            {'describe': {'id': 'project-xxx'}},
+            {},
+            {'describe': {'id': 'project-xxx'}}
+        ]
+    ).start()
+
+    # patch over datetime to simulate running on each day of the week,
+    # since the day param starts at 1 and 04/03/2024 was a Monday, we
+    # will add 3 for each iteration
+    patch(
+        'main.datetime',
+        Mock(today=lambda: datetime(2024, 3, day + 3))
+    ).start()
+
+    check_for_deletion(
+        seqs=["seq1", "seq2"],
+        genetics_dir="simulate_test",
+        logs_dir="simulate_test/logs",
+        ansible_week=2,
+        server_testing=False,
+        slack_token=os.environ.get("SLACK_TOKEN"),
+        pickle_file="check.pkl",
+        debug=True,
+        jira_assay=["MYE", "CEN", "TWE"],
+        jira_url=os.environ.get("SLACK_NOTIFY_JIRA_URL"),
+        jira=jira
+    )
+
+    patch.stopall()
+
+
+def simulate_deletion(jira) -> None:
+    """
+    Simulate running on a Wednesday and deleting runs according to what
+    is stored in the pickle file
+
+    Parameters
+    ----------
+    jira : jira.Jira
+        Jira object for Jira queries
+    """
+    print("Simulating deletion of run directories")
+
+    delete_runs(
+        pickle_file="check.pkl",
+        genetics_dir="simulate_test/",
+        jira_project_id=env.jira_project_id,
+        jira_reporter_id=env.jira_reporter_id,
+        slack_token=env.slack_token,
+        server_testing=env.server_testing,
+        debug=env.debug,
+        jira=jira
+    )
+
+
+def main():
+    print("Starting test run simulation...")
+
+    if os.environ.get('HTTPS_PROXY'):
+        # check if proxy set, if running locally and not on server this
+        # will cause POST requests to time out
+        print(
+            f"Note: HTTPS proxy address set: {os.environ.get('HTTPS_PROXY')}"
+        )
+
+    jira = Jira(
+        token=os.environ.get("JIRA_TOKEN"),
+        email=os.environ.get("JIRA_EMAIL"),
+        api_url=os.environ.get("JIRA_API_URL"),
+        debug=True
+    )
+
+    # simulate running the checking daily to check behaviour is correct
+    for day in range(1, 8):
+        # set up test data and Jira tickets
+        create_run_suffix()
+        delete_test_data()  # delete any old test data
+        create_test_run_directories()
+        create_test_logs()
+        issues = create_jira_tickets(jira=jira)
+
+        stop = False
+
+        try:
+            simulate_checking(jira=jira, day=day)
+        except Exception as err:
+            # ensure we always clean up test data
+            print(f"Error occured during checking: {err}")
+            stop = True
+
+        # clean up test data
+        delete_test_data()
+        delete_jira_tickets(jira, issues)
+
+        if stop:
+            print("Exiting now due to prior error")
+
+    # simulate_deletion(jira=jira)
+
+
+if __name__=="__main__":
+    main()

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -6,7 +6,7 @@ Runs with the following:
         - these should be logged as not old enough and excluded
     - Runs criteria that should be logged as error and flagged for manual review
         - 1 run old enough but no data uploaded (shouldn't happen)
-        - 1 run run old enough and uploaded to stagingArea but no 002 project
+        - 1 run run old enough and uploaded to stagingArea52 but no 002 project
         - 1 run old enough, uploaded and 002 project but ticket not in right state
     - 1 run that is old enough, uploaded, 002 project and ticket released
         - flagged to delete
@@ -276,7 +276,7 @@ def main():
         # check if proxy set, if running locally and not on server this
         # will cause POST requests to time out
         print(
-            f"Note: HTTPS proxy address set: {os.environ.get('HTTPS_PROXY')}"
+            f"NOTE: HTTPS proxy address set: {os.environ.get('HTTPS_PROXY')}"
         )
 
     jira = Jira(
@@ -309,8 +309,7 @@ def main():
             print("\nExiting now due to prior error")
             sys.exit()
 
-        # simulate_deletion(jira=jira, day=day)
-
+    # pretty print to sense check the expected directories are deleted
     print("Final directory state after running for the week:")
     for sub_path in sorted(Path('simulate_test/').rglob('*')):
         print(f"\t{sub_path}")

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -267,6 +267,50 @@ def simulate_end_to_end(day) -> None:
     patch.stopall()
 
 
+def check_correct_behaviour(day) -> list:
+    """
+    Check that the correct behaviour is observed for the given day of
+    the week, the expected behaviour for each day is as follows:
+
+    Monday -> 1 run identified as not old enough, 3 runs identified to
+        delete and 3 identified for manual intervention, Slack alert
+        sent and pickle file written to
+
+    Tuesday -> same as above but no Slack alert and no pickling
+
+    Wednesday -> same checks as above and runs deleted according to
+        pickle file, pickle file then deleted
+
+    Thursday-Sunday -> 1 run identified as not old enough, 3 identified
+        for manual intervention, no Slack alert sent
+
+    Parameters
+    ----------
+    day : int
+        day of the week
+
+    Returns
+    -------
+    list
+        any errors that have occurred
+    """
+    if day == 1:
+        # checks for Monday
+        pass
+    elif day == 2:
+        # checks for Tuesday
+        pass
+    elif day == 3:
+        # checks for Wednesday
+        pass
+    elif day in [4, 5, 6, 7]:
+        # checks for Thursday -> Sunday
+        pass
+    else:
+        # something has gone wrong
+        pass
+
+
 def main():
     print("Starting test run simulation...")
 

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -202,7 +202,7 @@ def delete_jira_tickets(jira, issues) -> None:
         jira.delete_issue(issue['id'])
 
 
-def simulate_end_to_end(jira, day) -> None:
+def simulate_end_to_end(day) -> None:
     """
     Run everything to test the checking of runs for deletion
 
@@ -221,8 +221,6 @@ def simulate_end_to_end(jira, day) -> None:
 
     Parameters
     ----------
-    jira : jira.Jira
-        Jira object for Jira queries
     day : int
         day of the week we're checking for
     """

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -35,6 +35,7 @@ import os
 from pathlib import Path
 import shutil
 import sys
+from unittest.mock import Mock, patch
 
 from dateutil.relativedelta import relativedelta
 from faker import Faker

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -31,6 +31,7 @@ The above needs to be tested on following days of the week:
 """
 from calendar import day_name
 from datetime import datetime
+import json
 import os
 from pathlib import Path
 import pickle
@@ -47,150 +48,141 @@ from bin.util import post_message_to_slack
 import monitor
 
 
-# suffix for random naming of test runs
-SUFFIX = ""
-
-
-def create_test_run_directories() -> None:
+class SetUp():
     """
-    Create test run data structure of 7 runs, all but the first we're
-    setting to be 'old enough' to delete (i.e. > ANSIBLE WEEKS old)
+    Simple methods for setting up required test data structure
     """
-    run_directories = [
-        f"seq1/run1_{SUFFIX}",
-        f"seq1/run2_{SUFFIX}",
-        f"seq1/run3_{SUFFIX}",
-        f"seq2/run4_{SUFFIX}",
-        f"seq2/run5_{SUFFIX}",
-        f"seq2/run6_{SUFFIX}",
-        f"seq2/run7_{SUFFIX}",
-    ]
+    def __init__(self, jira):
+        self.jira = jira
+        self.issues = []
+        self.suffix = None
 
-    os.makedirs("simulate_test", exist_ok=True)
-
-    today = datetime.today()
-
-    for idx, run in enumerate(run_directories, 2):
-        os.makedirs(f"simulate_test/{run}", exist_ok=True)
-
-        with open(f"simulate_test/{run}/test.file", "wb") as f:
-            # create test file of 1GB without actually writing any data to disk
-            f.truncate(1024 * 1024 * 1024)
-
-        # set run age to be sequentially 1 week older starting at 2 weeks old
-        age = (today + relativedelta(weeks=-idx)).timestamp()
-        os.utime(f"simulate_test/{run}", (age, age))
+        self.run_suffix()
+        self.test_run_directories()
+        self.test_logs()
+        self.jira_tickets()
 
 
-def create_test_logs() -> None:
+    def test_run_directories(self) -> None:
+        """
+        Create test run data structure of 7 runs, all but the first we're
+        setting to be 'old enough' to delete (i.e. > ANSIBLE WEEKS old)
+        """
+        run_directories = [
+            f"seq1/run1_{self.suffix}",
+            f"seq1/run2_{self.suffix}",
+            f"seq1/run3_{self.suffix}",
+            f"seq1/run4_{self.suffix}",
+            f"seq2/run5_{self.suffix}",
+            f"seq2/run6_{self.suffix}",
+            f"seq2/run7_{self.suffix}",
+        ]
+
+        os.makedirs("simulate_test", exist_ok=True)
+
+        today = datetime.today()
+
+        for idx, run in enumerate(run_directories, 2):
+            os.makedirs(f"simulate_test/{run}", exist_ok=True)
+
+            with open(f"simulate_test/{run}/test.file", "wb") as f:
+                # create test file of 1GB without actually writing any data to disk
+                f.truncate(1024 * 1024 * 1024)
+
+            # set run age to be sequentially 1 week older starting at 2 weeks old
+            age = (today + relativedelta(weeks=-idx)).timestamp()
+            os.utime(f"simulate_test/{run}", (age, age))
+
+
+    def test_logs(self) -> None:
+        """
+        Create required log files as generated from dx-streaming-upload, these
+        are used to checking if a directory is an monitored run directory
+        that we have started at least uploading
+        """
+        os.makedirs("simulate_test/logs/seq1", exist_ok=True)
+        os.makedirs("simulate_test/logs/seq2", exist_ok=True)
+
+        for idx in range(0, 8):
+            seq = 'seq1' if idx <5 else 'seq2'
+            open(
+                f"simulate_test/logs/{seq}/"
+                f"run.run{idx}_{self.suffix}.lane.all.log", "w"
+            ).close()
+
+
+    def jira_tickets(self) -> list:
+        """
+        Create required Jira tickets in required states for each run, this
+        will be as follows:
+            - run1 = not old enough -> NEW
+            - run2 = not uploaded -> NEW
+            - run3 = not processed -> New
+            - run4 = ticket not in right state -> On Hold
+            - run5 = released -> All Samples Released
+            - run6 = failed - not processed -> Data cannot be processed
+            - run7 = bad QC - not released -> Data cannot be released
+
+        Parameters
+        ----------
+        jira : jira.Jira
+            Jira object for Jira queries
+
+        # token : string
+        #     Jira API token
+        # email : string
+        #     Atlassian account email
+        # url : string
+        #     URL endpoint for test helpdesk
+        """
+        # mapping of run name to Jira issue state, these are numerical IDs
+        # associated to each state that we need to transition each ticket
+        # through, these can be found by going into the workflow edit mode
+        ticket_states = {
+            f"run1_{self.suffix}": None,
+            f"run2_{self.suffix}": None,
+            f"run3_{self.suffix}": None,
+            f"run4_{self.suffix}": None,
+            f"run5_{self.suffix}": [31, 41, 21],  # Data released
+            f"run6_{self.suffix}": [31, 61],      # Data cannot be processed
+            f"run7_{self.suffix}": [31, 41, 71]   # Data cannot be released
+        }
+
+        created_issues = []
+
+        for run, state in ticket_states.items():
+            print(f"Creating Jira issue for {run}")
+            issue = self.jira.create_issue(
+                summary=run,
+                issue_id=10179,    # issue type
+                project_id=10042,  # EBHD id
+                reporter_id="5c0e8b8d53cd043c8c6149eb",
+                priority_id=3,
+                desc="Ticket created as part of simulated testing of automated deletion",
+                assay=True,
+            )
+
+            created_issues.append(issue)
+            if state:
+                for transition in state:
+                    self.jira.make_transition(
+                        issue_id=issue['id'],
+                        transition_id=transition
+                    )
+
+        self.issues = created_issues
+
+
+    def run_suffix(self) -> None:
+        """
+        Generate random words to append to run ID to get a random name
+        """
+        self.suffix = '_'.join([Faker().word() for x in range(3)])
+
+
+class CleanUp():
     """
-    Create required log files as generated from dx-streaming-upload, these
-    are used to checking if a directory is an monitored run directory
-    that we have started at least uploading
-    """
-    os.makedirs("simulate_test/logs/seq1", exist_ok=True)
-    os.makedirs("simulate_test/logs/seq2", exist_ok=True)
-
-    for idx in range(0, 8):
-        open(
-            f"simulate_test/logs/seq1/"
-            f"run.run{idx}_{SUFFIX}.lane.all.log", "w"
-        ).close()
-
-
-def create_jira_tickets(jira) -> list:
-    """
-    Create required Jira tickets in required states for each run, this
-    will be as follows:
-        - run1 = not old enough -> NEW
-        - run2 = not uploaded -> NEW
-        - run3 = not processed -> New
-        - run4 = ticket not in right state -> On Hold
-        - run5 = released -> All Samples Released
-        - run6 = failed - not processed -> Data cannot be processed
-        - run7 = bad QC - not released -> Data cannot be released
-
-    Parameters
-    ----------
-    jira : jira.Jira
-        Jira object for Jira queries
-
-    # token : string
-    #     Jira API token
-    # email : string
-    #     Atlassian account email
-    # url : string
-    #     URL endpoint for test helpdesk
-    """
-    # mapping of run name to Jira issue state, these are numerical IDs
-    # associated to each state that we need to transition each ticket
-    # through, these can be found by going into the workflow edit mode
-    ticket_states = {
-        f"run1_{SUFFIX}": None,
-        f"run2_{SUFFIX}": None,
-        f"run3_{SUFFIX}": None,
-        f"run4_{SUFFIX}": None,
-        f"run5_{SUFFIX}": [31, 41, 21],  # Data released
-        f"run6_{SUFFIX}": [31, 61],      # Data cannot be processed
-        f"run7_{SUFFIX}": [31, 41, 71]   # Data cannot be released
-    }
-
-    created_issues = []
-
-    for run, state in ticket_states.items():
-        print(f"Creating Jira issue for {run}")
-        issue = jira.create_issue(
-            summary=run,
-            issue_id=10179,    # issue type
-            project_id=10042,  # EBHD id
-            reporter_id="5c0e8b8d53cd043c8c6149eb",
-            priority_id=3,
-            desc="Ticket created as part of simulated testing of automated deletion",
-            assay=True,
-        )
-
-        created_issues.append(issue)
-        if state:
-            for transition in state:
-                jira.make_transition(
-                    issue_id=issue['id'],
-                    transition_id=transition
-                )
-
-    return created_issues
-
-
-def create_run_suffix() -> None:
-    """
-    Generate random words to append to run ID to get a random name,
-    dumping this into globals for every time it is called as too lazy
-    to go back and pass it around
-    """
-    fake = Faker()
-    global SUFFIX
-    SUFFIX='_'.join([fake.word() for x in range(3)])
-
-
-def delete_test_data() -> None:
-    """
-    Check for test data directories and pickle file to clean up
-    """
-    print("Cleaning up test data directories")
-    if os.path.exists('simulate_test'):
-        shutil.rmtree('simulate_test')
-
-
-def delete_pickle() -> None:
-    """
-    Delete the saved pickle file
-    """
-    if os.path.exists("check.pkl"):
-        os.remove("check.pkl")
-
-
-def delete_jira_tickets(jira, issues) -> None:
-    """
-    Delete Jira issue tickets we created as part of testing
+    Simple methods for cleaning up test data
 
     Parameters
     ----------
@@ -199,12 +191,219 @@ def delete_jira_tickets(jira, issues) -> None:
     ids : list
         list of created Jira issue IDs
     """
-    print("Deleting test Jira issues")
-    for issue in issues:
-        jira.delete_issue(issue['id'])
+    def __init__(self, jira=None, issues=None):
+        self.jira = jira
+        self.issues = issues
+
+        self.test_data()
+        self.pickle()
+        self.logging_log()
+        self.recorded_deletion_log()
+        self.jira_tickets()
 
 
-def simulate_end_to_end(day) -> None:
+    def test_data(self) -> None:
+        """
+        Check for test data directories and pickle file to clean up
+        """
+        print("Cleaning up test data directories")
+        if os.path.exists('simulate_test'):
+            shutil.rmtree('simulate_test')
+
+
+    def pickle(self) -> None:
+        """
+        Delete the saved pickle file
+        """
+        if os.path.exists("check.pkl"):
+            os.remove("check.pkl")
+
+
+    def recorded_deletion_log(self) -> None:
+        """
+        Delete output log of deleted run directories
+        """
+        if os.path.exists("ansible_delete.txt"):
+            os.remove("ansible_delete.txt")
+
+
+    def logging_log(self) -> None:
+        """
+        Delete log file of stdout logging
+        """
+        return
+        if os.path.exists("ansible-run-monitoring.log"):
+            os.remove("ansible-run-monitoring.log")
+
+
+    def jira_tickets(self) -> None:
+        """
+        Delete Jira issue tickets we created as part of testing
+        """
+        if self.jira and self.issues:
+            print("Deleting test Jira issues")
+            for issue in self.issues:
+                self.jira.delete_issue(issue['id'])
+
+
+class CheckBehaviour():
+    """
+    Check that the correct behaviour is observed for the given day of
+    the week, the expected behaviour for each day is as follows:
+
+    Monday -> 1 run identified as not old enough, 3 runs identified to
+        delete and 3 identified for manual intervention, Slack alert
+        sent and pickle file written to
+
+    Tuesday -> same as above but no Slack alert and no pickling
+
+    Wednesday -> same checks as above and runs deleted according to
+        pickle file, pickle file then deleted
+
+    Thursday-Sunday -> 1 run identified as not old enough, 3 identified
+        for manual intervention, no Slack alert sent
+
+    Parameters
+    ----------
+    day : int
+        day of the week
+    suffix : str
+        randomly generated suffix string used for naming test directories
+    slack_mock : mock.MagicMock
+        Mock object for Slack notifications
+    """
+    def __init__(self, day, suffix, slack_mock):
+        self.day = day
+        self.suffix = suffix
+        self.slack_mock = slack_mock
+
+        self.errors = []
+        self.runs_not_to_delete = [f"seq1/run{x}_{suffix}" for x in range(1, 5)]
+        self.runs_to_delete = [f"seq2/run{x}_{suffix}" for x in range(5, 8)]
+
+        if day == 1:
+            self.check_monday()
+        elif day == 2:
+            self.check_tuesday()
+        elif day == 3:
+            self.check_wednesday()
+        elif day in [4, 5, 6, 7]:
+            self.check_thursday_to_sunday()
+        else:
+            # something has gone wrong
+            print(f"Checking invalid day: {day}")
+
+
+    def check_monday(self) -> None:
+        """
+        Check behaviour for running on Monday
+
+        We expect to push 2 Slack notifications, update our pickle file
+        with runs 5-7 to delete but not delete any directories
+        """
+        if self.slack_mock.call_count != 2:
+            # we expect 2 calls to send Slack notifications
+            self.errors.append(
+                "Incorrect number of calls to Slack made: "
+                f"{self.slack_mock.call_count}"
+            )
+
+        # TODO: check for contents of what is sent in Slack alert
+
+        expected_pickle = (
+            f"{os.environ.get('ANSIBLE_PICKLE_PATH')}/ansible_dict.test.pickle"
+        )
+        if not os.path.exists(expected_pickle):
+            # check we have a pickle
+            self.errors.append(
+                "Pickle file of runs to delete not generated "
+                f"at {expected_pickle}"
+            )
+        else:
+            # check the pickle contains what we expect, keys will be the
+            # run ID
+            with open(expected_pickle, "rb") as f:
+                pickle_contents = pickle.load(f)
+
+            pickled_runs = sorted([
+                x.split('_')[0] for x in pickle_contents.keys()
+            ])
+
+            if not pickled_runs == ['run5', 'run6', 'run7']:
+                self.errors.append(
+                    "Expected runs to delete not in pickle file, runs found: "
+                    f"{pickle_contents.keys()}"
+                )
+
+
+    def check_tuesday(self) -> None:
+        """
+        Check behaviour for running on Tuesday
+
+        We expect no Slack notifications, for the pickle file to be
+        unmodified and for no deletion to take place
+        """
+        for run in self.runs_not_to_delete + self.runs_to_delete:
+            # all run directories should still exist
+            run_path = os.path.join(os.environ.get("ANSIBLE_GENETICDIR"), run)
+
+            if not os.path.exists(run_path):
+                self.errors.append(
+                    f"Run directory wrongly deleted: {run_path}"
+                )
+
+        if self.slack_mock.call_count != 0:
+            # we expect no calls to send Slack notifications
+            self.errors.append("Slack notifications wrongly sent")
+
+
+    def check_wednesday(self) -> None:
+        """
+        Check behaviour for running on Wednesday, we expect to delete the
+        runs according to what was in the pickle file
+        """
+        for run in self.runs_not_to_delete:
+            # check runs we *should not* have deleted
+            run_path = os.path.join(os.environ.get("ANSIBLE_GENETICDIR"), run)
+            if not os.path.exists(run_path):
+                self.errors.append(
+                    f"Run directory wrongly deleted: {run_path}"
+                )
+
+        for run in self.runs_to_delete:
+            # check runs be *should* have deleted
+            run_path = os.path.join(os.environ.get("ANSIBLE_GENETICDIR"), run)
+            if os.path.exists(run_path):
+                self.errors.append(
+                    f"Run directory should have been deleted: {run_path}"
+                )
+
+        if self.slack_mock.call_count != 0:
+            # we expect no calls to send Slack notifications
+            self.errors.append("Slack notifications wrongly sent")
+
+
+    def check_thursday_to_sunday(self) -> None:
+        """
+        Check behaviour for running on Thursday - Sunday
+
+        We should not be deleting anything, sending no Slack notifications
+        and the pickle file should be unmodified
+        """
+        for run in self.runs_not_to_delete:
+            # everything should still exist
+            run_path = os.path.join(os.environ.get("ANSIBLE_GENETICDIR"), run)
+            if not os.path.exists(run_path):
+                self.errors.append(
+                    f"Run directory wrongly deleted: {run_path}"
+                )
+
+        if self.slack_mock.call_count != 0:
+            # we expect no calls to send Slack notifications
+            self.errors.append("Slack notifications wrongly sent")
+
+
+def simulate_end_to_end(day, suffix) -> list:
     """
     Run everything to test the checking of runs for deletion
 
@@ -225,6 +424,13 @@ def simulate_end_to_end(day) -> None:
     ----------
     day : int
         day of the week we're checking for
+    suffix : str
+        randomly generated suffix string used for naming test directories
+
+    Returns
+    -------
+    list
+        list of any encountered errors
     """
     print("Simulating end to end running of checking and deletion")
     # below we will mock the function calls to dxpy to not need to create
@@ -277,123 +483,15 @@ def simulate_end_to_end(day) -> None:
     monitor.main()
 
     # check our behaviour is correct and build summary
-    CheckBehaviour(
+    checks = CheckBehaviour(
         day=day,
+        suffix=suffix,
         slack_mock=slack_mock
     )
 
     patch.stopall()
 
-
-class CheckBehaviour():
-    """
-    Check that the correct behaviour is observed for the given day of
-    the week, the expected behaviour for each day is as follows:
-
-    Monday -> 1 run identified as not old enough, 3 runs identified to
-        delete and 3 identified for manual intervention, Slack alert
-        sent and pickle file written to
-
-    Tuesday -> same as above but no Slack alert and no pickling
-
-    Wednesday -> same checks as above and runs deleted according to
-        pickle file, pickle file then deleted
-
-    Thursday-Sunday -> 1 run identified as not old enough, 3 identified
-        for manual intervention, no Slack alert sent
-
-    Parameters
-    ----------
-    day : int
-        day of the week
-    """
-    def __init__(self, day, slack_mock):
-        self.day = day
-        self.slack_mock = slack_mock
-        self.errors = {
-            "Monday": [],
-            "Tuesday": [],
-            "Wednesday": [],
-            "Thursday": [],
-            "Friday": [],
-            "Saturday": [],
-            "Sunday": []
-        }
-
-        if day == 1:
-            self.check_monday()
-        elif day == 2:
-            self.check_tuesday()
-        elif day == 3:
-            self.check_wednesday()
-        elif day in [4, 5, 6, 7]:
-            self.check_thursday_to_sunday()
-        else:
-            # something has gone wrong
-            pass
-
-
-    def check_monday(self) -> None:
-        """
-        Check behaviour for running on Monday
-        """
-        weekday = {day_name[self.day-1]}
-        print(f"Checking behaviour for {weekday}")
-
-        errors = []
-
-        if self.slack_mock.call_count != 2:
-            # we expect 2 calls to send Slack notifications
-            errors.append(
-                "Incorrect number of calls to Slack made: "
-                f"{self.slack_mock.call_count}"
-            )
-
-        # TODO: check logs for contents of slack alert for manual runs
-
-
-        expected_pickle = (
-            f"{os.environ.get('ANSIBLE_PICKLE_PATH')}/ansible_dict.test.pickle"
-        )
-        if not os.path.exists(expected_pickle):
-            # check we have a pickle
-            self.errors[weekday].append(
-                "Pickle file of runs to delete not generated "
-                f"at {expected_pickle}"
-            )
-        else:
-            # check the pickle contains what we expect
-            with open(expected_pickle, "rb") as f:
-                pickle_contents = pickle.load(f)
-
-            pickled_runs = sorted([
-                x.split('_')[0] for x in pickle_contents.keys()
-            ])
-
-            if not pickled_runs == ['run5', 'run6', 'run7']:
-                self.errors[weekday].append(
-                    "Expected runs to delete not in pickle file, runs found: "
-                    f"{pickle_contents.keys()}"
-                )
-
-
-    def check_tuesday(self) -> None:
-        """
-        Check behaviour for running on Tuesday
-        """
-        pass
-
-    def check_wednesday(self) -> None:
-        """
-        Check behaviour for running on Wednesday
-        """
-        pass
-
-    def check_thursday_to_sunday(self) -> None:
-        """
-        Check behaviour for running on Thursday - Sunday
-        """
-        pass
+    return checks.errors
 
 
 def main():
@@ -413,25 +511,29 @@ def main():
         debug=True
     )
 
+    # delete any old test data
+    CleanUp()
+
     # set up test data and Jira tickets
-    create_run_suffix()
-    delete_test_data()  # delete any old test data
-    create_test_run_directories()
-    create_test_logs()
-    issues = create_jira_tickets(jira=jira)
+    test_data = SetUp(jira=jira)
+
+    errors = {}
 
     # simulate running the checking daily to check behaviour is correct
     for day in range(1, 8):
         print(f"\nStarting simulated check for {day_name[day - 1]}")
         try:
-            simulate_end_to_end(day=day)
+            daily_errors = simulate_end_to_end(
+                day=day,
+                suffix=test_data.suffix
+            )
+            errors[day_name[day -1]] = daily_errors
         except Exception:
             # ensure we always clean up test data
             print(f"Error occurred during checking")
             print(traceback.format_exc())
 
-            delete_test_data()
-            delete_jira_tickets(jira, issues)
+            CleanUp(jira=jira, issues=test_data.issues)
 
             print("\nExiting now due to prior error")
             sys.exit()
@@ -442,8 +544,16 @@ def main():
         print(f"\t{sub_path}")
 
     # clean up test data
-    delete_test_data()
-    delete_jira_tickets(jira, issues)
+    CleanUp(jira=jira, issues=test_data.issues)
+
+    if any(errors.values()):
+        # one or more checks did not pass
+        print(f"\nOne or more errors occurred from daily checks")
+        for day, error in errors.items():
+            if error:
+                print(f"{day}:", json.dumps(error, indent='  '))
+    else:
+        print("\nDaily checking worked as expected, no errors detected")
 
 
 if __name__=="__main__":

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -155,7 +155,7 @@ def create_jira_tickets(jira) -> list:
 
 def create_run_suffix() -> None:
     """
-    Generate a random word to append to run ID to get a random name,
+    Generate random words to append to run ID to get a random name,
     dumping this into globals for every time it is called as too lazy
     to go back and pass it around
     """

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -168,7 +168,7 @@ def delete_test_data() -> None:
     """
     Check for test data directories and pickle file to clean up
     """
-    print("Deleting test data directories")
+    print("Cleaning up test data directories")
     if os.path.exists('simulate_test'):
         shutil.rmtree('simulate_test')
 
@@ -246,7 +246,7 @@ def simulate_checking(jira, day) -> None:
 
     # patch over datetime to simulate running on each day of the week,
     # since the day param starts at 1 and 04/03/2024 was a Monday, we
-    # will add 3 for each iteration
+    # will add 3 to each iteration to start from Monday
     patch(
         'main.datetime',
         Mock(today=lambda: datetime(2024, 3, day + 3))
@@ -269,7 +269,7 @@ def simulate_checking(jira, day) -> None:
     patch.stopall()
 
 
-def simulate_deletion(jira) -> None:
+def simulate_deletion(jira, day) -> None:
     """
     Simulate running on a Wednesday and deleting runs according to what
     is stored in the pickle file
@@ -278,8 +278,18 @@ def simulate_deletion(jira) -> None:
     ----------
     jira : jira.Jira
         Jira object for Jira queries
+    day : int
+        day of the week we are (potentially) deleting for
     """
     print("Simulating deletion of run directories")
+
+    # patch over datetime to simulate running on each day of the week,
+    # since the day param starts at 1 and 04/03/2024 was a Monday, we
+    # will add 3 to each iteration to start from Monday
+    patch(
+        'main.datetime',
+        Mock(today=lambda: datetime(2024, 3, day + 3))
+    ).start()
 
     delete_runs(
         pickle_file="check.pkl",
@@ -342,7 +352,7 @@ def main():
             print("Exiting now due to prior error")
             sys.exit()
 
-        simulate_deletion(jira=jira)
+        simulate_deletion(jira=jira, day=day)
 
         # clean up test data
         delete_test_data()

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -89,13 +89,11 @@ def create_test_logs() -> None:
     os.makedirs("simulate_test/logs/seq1", exist_ok=True)
     os.makedirs("simulate_test/logs/seq2", exist_ok=True)
 
-    open(f"simulate_test/logs/seq1/run.run1_{SUFFIX}.lane.all.log", "w").close()
-    open(f"simulate_test/logs/seq1/run.run2_{SUFFIX}.lane.all.log", "w").close()
-    open(f"simulate_test/logs/seq1/run.run3_{SUFFIX}.lane.all.log", "w").close()
-    open(f"simulate_test/logs/seq2/run.run4_{SUFFIX}.lane.all.log", "w").close()
-    open(f"simulate_test/logs/seq2/run.run5_{SUFFIX}.lane.all.log", "w").close()
-    open(f"simulate_test/logs/seq2/run.run6_{SUFFIX}.lane.all.log", "w").close()
-    open(f"simulate_test/logs/seq2/run.run7_{SUFFIX}.lane.all.log", "w").close()
+    for idx in range(0, 8):
+        open(
+            f"simulate_test/logs/seq1/"
+            f"run.run{idx}_{SUFFIX}.lane.all.log", "w"
+        ).close()
 
 
 def create_jira_tickets(jira) -> list:


### PR DESCRIPTION
- started work on changing deletion logic to allow for weekly clearing of data
- intended behaviour is to run check on a Monday for runs to delete, then perform deletion on the Wednesday
- switch to also automatically delete runs which have a Jira ticket status in `DATA CANNOT BE RELEASED` and `DATA CANNOT BE PROCESSED` - fixes #18 
- refactored core logic into 2 functions:
  - `check_for_deletion()` - main logic for determining what meets criteria for deletion and storing in pickle file
  - `delete_runs()` - actually deletes the run data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/ansible-run-monitoring/28)
<!-- Reviewable:end -->
