### PR TITLE
v1.1.0 - fix simulated run age

### DIFF
--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -81,16 +81,18 @@ class SetUp:
 
         os.makedirs("simulate_test", exist_ok=True)
 
-        today = datetime.today()
+        # in simulate_end_to_end() we patch over datetime.today() in
+        # monitor.main as starting from 4/3/2024 => we will create runs
+        # being sequentially one week older from here
+        today = datetime(2024, 3, 4)
 
-        for idx, run in enumerate(run_directories, 2):
+        for idx, run in enumerate(run_directories, 1):
             os.makedirs(f"simulate_test/{run}", exist_ok=True)
 
             with open(f"simulate_test/{run}/test.file", "wb") as f:
                 # create test file of 1GB without actually writing any data to disk
                 f.truncate(1024 * 1024 * 1024)
 
-            # set run age to be sequentially 1 week older starting at 2 weeks old
             age = (today + relativedelta(weeks=-idx)).timestamp()
             os.utime(f"simulate_test/{run}", (age, age))
 

--- a/simulate_test_runs.py
+++ b/simulate_test_runs.py
@@ -93,6 +93,7 @@ class SetUp:
                 # create test file of 1GB without actually writing any data to disk
                 f.truncate(1024 * 1024 * 1024)
 
+            # set run age to be sequentially 1 week older starting at 1 weeks old
             age = (today + relativedelta(weeks=-idx)).timestamp()
             os.utime(f"simulate_test/{run}", (age, age))
 


### PR DESCRIPTION
- fix the run age in end to end test to always be n weeks older than 4/3/2024 (the date used to patch over `datetime.today()` in the simulated daily check
- this means each of the 7 runs are incrementally created at one week older than the fixed date to match the expected behaviour of the test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/ansible-run-monitoring/32)
<!-- Reviewable:end -->
